### PR TITLE
Replace link for garbage podcast

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ In this section you can find sites presenting news about BSD.
 
 * [BSDNow](http://www.bsdnow.tv/) -  weekly BSD podcast, featuring news, interviews and tutorials, in MP3, OGG and MP4
 * [BSDTalk](http://bsdtalk.blogspot.com/) - Talking about the BSD family of free operating systems.
-* [Garbage](http://garbage.fm/) - A podcast about technology, much of it garbage
+* [Garbage (archive)](https://garbage.jcs.org/) - A podcast about technology, much of it garbage. (Archived episodes)
 
 ## Forums and Communities
 


### PR DESCRIPTION
The garbage podcast has been stopped, and the archived episodes have
been moved to jcs@ site. As such, the link has been replaced with the
archive URL and the text has been updated to indicate it is an archive