### PR TITLE
GhostBSD update and FuryBSD removal.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ FuryBSD is a brand new, open source FreeBSD desktop. FuryBSD pays homage to desk
 * [twitter](https://twitter.com/freebsd)
 
 ### GhostBSD
-GhostBSD is a user-friendly BSD operating system built on top of [TrueOS](#trueos). GhostBSD aims to provide a familiar workstation with all of the features and benefits of FreeBSD, combined with a twist that is the MATE desktop environment and a focus on user-friendliness. Available in both 32- and 64-bit versions, GhostBSD is suitable for newcomers, as well as experienced BSD users.
+GhostBSD is a user-friendly BSD operating system built on top of [FreeBSD](#freebsd). GhostBSD aims to provide a familiar workstation with all of the features and benefits of FreeBSD, combined with a twist that is the MATE desktop environment and a focus on user-friendliness. Available in both 32- and 64-bit versions, GhostBSD is suitable for newcomers, as well as experienced BSD users.
 
 * [official site](http://www.ghostbsd.org)
 * [download](http://www.ghostbsd.org/download)

--- a/README.md
+++ b/README.md
@@ -54,13 +54,6 @@ FreeBSD is an advanced computer operating system used to power modern servers, d
 * [handbook](https://www.freebsd.org/doc/en_US.ISO8859-1/books/handbook/)
 * [mailing list](https://www.freebsd.org/community/mailinglists.html)
 
-### FuryBSD
-FuryBSD is a brand new, open source FreeBSD desktop. FuryBSD pays homage to desktop BSD projects of the past like PC-BSD and TrueOS with its graphical interface and adds additional tools like a live, hybrid USB / DVD image. FuryBSD is available with either XFCE or KDE.
-
-* [official site](https://www.furybsd.org/)
-* [forum](https://forums.furybsd.org/)
-* [twitter](https://twitter.com/freebsd)
-
 ### GhostBSD
 GhostBSD is a user-friendly BSD operating system built on top of [FreeBSD](#freebsd). GhostBSD aims to provide a familiar workstation with all of the features and benefits of FreeBSD, combined with a twist that is the MATE desktop environment and a focus on user-friendliness. Available in both 32- and 64-bit versions, GhostBSD is suitable for newcomers, as well as experienced BSD users.
 


### PR DESCRIPTION
GhostBSD is no longer based on TrueOS but FreeBSD. FuryBSD is dead so I removed it.

closes #35  #34 