### PR TITLE
README: order, and an update for Unix Linux Community

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ BSD Router Project (BSDRP) is an embedded free and open source router distributi
 * [download](https://bsdrp.net/downloads?DokuWiki=e8a2af21cc91416f910347e472b73841)
 * [mailing list](https://bsdrp.net/community/mailing_lists)
 
+### CheriBSD
+[CHERI (Capability Hardware Enhanced RISC Instructions)](https://www.cl.cam.ac.uk/research/security/ctsrd/cheri/) is a joint research project of SRI International and the University of Cambridge to revisit fundamental design choices in hardware and software to dramatically improve system security. CheriBSD is an adaptation of the open-source FreeBSD operating system to support the CHERI-MIPS, CHERI-RISC-V, and Arm Morello ISAs. 
+
+* [official site](https://www.cl.cam.ac.uk/research/security/ctsrd/cheri/cheribsd.html)
+* [download](https://cheri-dist.cl.cam.ac.uk/)
+* [CTSRD-CHERI/cheribsd](https://github.com/CTSRD-CHERI/cheribsd)
+
 ### DragonFly BSD
 DragonFly belongs to the same class of operating systems as other BSD-derived systems and Linux. It is based on the same UNIX ideals and APIs and shares ancestor code with other BSD operating systems. DragonFly provides an opportunity for the BSD base to grow in an entirely different direction from the one taken in the FreeBSD, NetBSD, and OpenBSD series. 
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ This document is a database of links related to the BSD operating systems and BS
 
 [Structure](https://github.com/DiscoverBSD/BSD-Links/issues/1) is as follows:
  
-* [Operating systems](#operating-systems) – official links
+* [Operating systems](#operating-systems) – official and other links
 * [BSD news](#bsd-news) – where to look for news
-* [Forums and communities](#forums-and-communities) – Reddit, forums, meetups etc
+* [Forums and communities](#forums-and-communities) – forums, meetups etc
 * [Learning](#learning) – where to learn BSD
 * [Books](#books) – books about BSD
 * [BSD-related software](#bsd-related-software)
@@ -24,11 +24,11 @@ Bitrig is a free, fast, and secure Unix-like Open Source operating system. It is
 * [Twitter](https://twitter.com/bitrig)
 
 ### BSD Router Project
-BSD Router Project (BSDRP) is an embedded free and open source router distribution based on [FreeBSD](http://www.freebsd.org/) with [Quagga](http://www.quagga.net/) and [Bird](http://bird.network.cz/).
+BSD Router Project (BSDRP) is an embedded free and open source router distribution based on [FreeBSD](https://www.freebsd.org/) with [Quagga](https://www.quagga.net/) and [BIRD](https://bird.network.cz/).
 
-* [official site](http://bsdrp.net/)
-* [download](http://bsdrp.net/downloads?DokuWiki=e8a2af21cc91416f910347e472b73841)
-* [mailing list](http://bsdrp.net/community/mailing_lists)
+* [official site](https://bsdrp.net/)
+* [download](https://bsdrp.net/downloads?DokuWiki=e8a2af21cc91416f910347e472b73841)
+* [mailing list](https://bsdrp.net/community/mailing_lists)
 
 ### DragonFly BSD
 DragonFly belongs to the same class of operating systems as other BSD-derived systems and Linux. It is based on the same UNIX ideals and APIs and shares ancestor code with other BSD operating systems. DragonFly provides an opportunity for the BSD base to grow in an entirely different direction from the one taken in the FreeBSD, NetBSD, and OpenBSD series. 
@@ -37,9 +37,11 @@ DragonFly belongs to the same class of operating systems as other BSD-derived sy
 * [download](http://www.dragonflybsd.org/download/)
 * [mailing list](http://www.dragonflybsd.org/mailinglists/)
 * [handbook](http://www.dragonflybsd.org/docs/newhandbook/)
+* [/r/dragonflybsd](https://www.reddit.com/r/dragonflybsd)
+* [DragonFly BSD Digest](https://www.dragonflydigest.com/) – a running description of activity related to DragonFly BSD.
 
 ### EdgeBSD
-EdgeBSD is a new member of the family of [BSD](http://en.wikipedia.org/wiki/BSD)-based Operating Systems, starting development with the current [NetBSD](http://www.netbsd.org/) codebase with [Git](http://git-scm.com/) for Source Code Management. Package management is based on [pkgsrc](http://pkgsrc.org/).
+EdgeBSD is a new member of the family of [BSD](https://en.wikipedia.org/wiki/Berkeley_Software_Distribution)-based Operating Systems, starting development with the current [NetBSD](https://www.netbsd.org/) codebase with [Git](https://git-scm.com/) for Source Code Management. Package management is based on [pkgsrc](https://pkgsrc.org/).
 
 * [official site](https://www.edgebsd.org/)
 * [projects](https://www.edgebsd.org/edgebsd/project)
@@ -51,17 +53,20 @@ Founded in 1993, FreeBSD is an advanced operating system that powers modern [des
 * [official site](https://www.freebsd.org)
 * [download](https://www.freebsd.org/where.html)
 * [forum](https://forums.freebsd.org/)
-* [Twitter](https://twitter.com/freebsd)
 * [handbook](https://docs.freebsd.org/en/books/handbook/)
 * [mailing list](https://www.freebsd.org/community/mailinglists/)
+* [FreshPorts](https://www.freshports.org/)
+* [/r/freebsd](https://www.reddit.com/r/freebsd) 
+* [Twitter](https://twitter.com/freebsd)
+* [FreeBSDNews](https://www.freebsdnews.com/) – a blog advocating FreeBSD and offering project news and advice.
 
 ### GhostBSD
 GhostBSD is a user-friendly BSD operating system built on top of [FreeBSD](#freebsd). GhostBSD aims to provide a familiar workstation with all of the features and benefits of FreeBSD, combined with a twist that is the MATE desktop environment and a focus on user-friendliness. Available in both 32- and 64-bit versions, GhostBSD is suitable for newcomers, as well as experienced BSD users.
 
-* [official site](http://www.ghostbsd.org)
-* [download](http://www.ghostbsd.org/download)
-* [forums](http://forums.ghostbsd.org/)
-* [handbook](http://wiki.ghostbsd.org/index.php?title=GhostBSD_User_Handbook)
+* [official site](https://www.ghostbsd.org/)
+* [download](https://www.ghostbsd.org/download)
+* [forums](https://forums.ghostbsd.org/)
+* [handbook](https://wiki.ghostbsd.org/index.php/GhostBSD_User_Handbook)
 
 ### HardenedBSD
 HardenedBSD is a security-enhanced fork of FreeBSD. The HardenedBSD Project is implementing many exploit mitigation and security technologies on top of FreeBSD.
@@ -70,6 +75,7 @@ HardenedBSD is a security-enhanced fork of FreeBSD. The HardenedBSD Project is i
 * [download](http://jenkins.hardenedbsd.org/)
 * [mailing list](https://hardenedbsd.org/content/mailing-lists)
 * [wiki](https://github.com/HardenedBSD/hardenedBSD/wiki)
+* [/r/hardenedbsd](https://www.reddit.com/r/hardenedbsd)
 
 ### helloSystem
 helloSystem is a desktop system for creators with a focus on simplicity, elegance, and usability. Its design follows the “Less, but better” philosophy. It is intended as a system for “mere mortals”, welcoming to switchers from the Mac. [FreeBSD](#freebsd) is used as the core operating system. 
@@ -87,9 +93,9 @@ LiteBSD is variant of 4.4BSD operating system for microcontrollers. Currently, o
 ### MidnightBSD
 MidnightBSD is a new BSD-derived operating system developed with desktop users in mind. It includes all the software you'd expect for your daily tasks — email, web browsing, word processing, gaming, and much more. With a small community of dedicated developers, MidnightBSD strives to create an easy-to-use operating system everyone can use, freely. Available for x86, AMD64 and as Virtual Machines.
 
-* [official site](http://www.midnightbsd.org/)
-* [download](http://www.midnightbsd.org/download/)
-* [mailing list](http://www.midnightbsd.org/mailman/listinfo/)
+* [official site](https://www.midnightbsd.org/)
+* [download](https://www.midnightbsd.org/download/)
+* [mailing list](https://www.midnightbsd.org/mailman/listinfo/)
 * [Twitter](https://twitter.com/midnightbsd)
 
 ### MirOS
@@ -103,8 +109,8 @@ MirOS BSD is a secure operating system from the BSD family for 32-bit i386 and s
 
 NomadBSD is a 64bit live system for USB flash drives, based on FreeBSD. Together with automatic hardware detection and setup, it is configured to be used as a desktop system that works out of the box, but can also be used for data recovery.       
 
- * [official site](http://nomadbsd.org/)
- * [download](http://nomadbsd.org/download.html)
+ * [official site](https://nomadbsd.org/)
+ * [download](https://nomadbsd.org/download.html)
  * [mailing list](https://www.freelists.org/list/nomadbsddevs)
 
 ### NetBSD
@@ -114,6 +120,8 @@ NetBSD is a free, fast, secure, and highly portable Unix-like Open Source operat
 * [download](https://netbsd.org/releases/)
 * [guide](https://netbsd.org/docs/guide/en/)
 * [mailing list](https://netbsd.org/mailinglists/)
+* [/r/netbsd](https://www.reddit.com/r/netbsd)
+* [NetBSD Planet](https://netbsd.fi/)
 
 ### NextBSD
 NextBSD is a code name for "science project", a name which is more tongue-in-cheek than serious (naming projects is hard). It started as an effort to adapt some of the more interesting Open Source technologies from Darwin/OS X to FreeBSD.
@@ -122,14 +130,17 @@ NextBSD is a code name for "science project", a name which is more tongue-in-che
 * [download](https://github.com/nextbsd)
 
 ### OpenBSD
-The OpenBSD project produces a FREE, multi-platform 4.4BSD-based UNIX-like operating system. Our efforts emphasize portability, standardization, correctness, [proactive security](http://www.openbsd.org/security.html) and [integrated cryptography](http://www.openbsd.org/crypto.html). As an example of the effect OpenBSD has, the popular [OpenSSH](http://www.openssh.com/) software comes from OpenBSD. 
+The OpenBSD project produces a FREE, multi-platform 4.4BSD-based UNIX-like operating system. Our efforts emphasize portability, standardization, correctness, [proactive security](https://www.openbsd.org/security.html) and [integrated cryptography](https://www.openbsd.org/crypto.html). As an example of the effect OpenBSD has, the popular [OpenSSH](https://www.openssh.com/) software comes from OpenBSD. 
 
-* [official site](http://www.openbsd.org)
-* [download](http://www.openbsd.org/ftp.html)
-* [mailing list](http://www.openbsd.org/mail.html)
+* [official site](https://www.openbsd.org)
+* [download](https://www.openbsd.org/ftp.html)
+* [mailing list](https://www.openbsd.org/mail.html)
+* [OpenBSD Jumpstart](https://www.openbsdjumpstart.org)
+* [/r/openbsd](https://www.reddit.com/r/openbsd)
+* [/r/openbsd_gaming/](https://www.reddit.com/r/openbsd_gaming)
 * [Twitter](https://twitter.com/openbsd)
-* [openbsd-awesome](https://github.com/ligurio/openbsd-awesome) – the curated list of awesome OpenBSD products, vacancies and resources
-* [OpenBSD Jumpstart](http://www.openbsdjumpstart.org/)
+* [Awesome OpenBSD](https://github.com/ligurio/openbsd-awesome) – a curated list of resources
+* [OpenBSD Journal](https://undeadly.org/) – a resource for the OpenBSD community
 
 ### OPNsense
 OPNsense is an open source,easy-to-use and easy-to-build FreeBSD based firewall and routing platform. OPNsense includes most of the features available in expensive commercial firewalls, and more in many cases. OPNsense® is a fork of pfSense® that in its turn has been forked from m0n0wall®.
@@ -137,6 +148,8 @@ OPNsense is an open source,easy-to-use and easy-to-build FreeBSD based firewall 
 * [official site](https://opnsense.org)
 * [download](https://opnsense.org/download/)
 * [mailing list](https://opnsense.org/support-overview/mailing-list/)
+* [/r/opnsense](https://www.reddit.com/r/opnsense)
+* [/r/OPNsenseFirewall](https://www.reddit.com/r/OPNsenseFirewall)
 * [Twitter](https://twitter.com/opnsense)
 
 ### OS108
@@ -155,12 +168,12 @@ pfSense® software is a free, open source customized distribution of FreeBSD spe
 ### RaspBSD
 RaspBSD is a image of FreeBSD 11 that is preconfigured in two different images for Raspberry Pi Computers (and more soon).
 
-* [official site](http://raspbsd.org)
+* [official site](http://raspbsd.org/)
 
 ### RetroBSD
 RetroBSD is a port of 2.11BSD Unix intended for embedded systems with fixed memory mapping. The current target is Microchip PIC32 microcontroller with 128 kbytes of RAM and 512 kbytes of Flash. PIC32 processor has MIPS M4K architecture, executable data memory and flexible RAM partitioning between user and kernel modes.
 
-* [official site](http://retrobsd.org)
+* [official site](http://retrobsd.org/)
 * [download](http://retrobsd.org/wiki/autobuild.php)
 
 ### SmallWall
@@ -168,20 +181,20 @@ A long time ago, a very smart guy asked a very simple question. "Why do firewall
 
 * [official site](http://www.smallwall.org/)
 * [downloads](http://www.smallwall.org/download.html)
-* [forums](http://smallwall.freeforums.net/)
+* [forums](https://smallwall.freeforums.net/)
 
 ### t1n1wall
 As m0n0wall decided to close it's doors, and no further development is planned, people have created this fork.
 
-* [official site](http://t1n1wall.com/)
-* [downloads](http://sourceforge.net/projects/t1n1wall/files/?source=navbar)
-* [forums](http://forums.t1n1wall.com/)
+* [official site](https://t1n1wall.com/)
+* [downloads](https://sourceforge.net/projects/t1n1wall/files/)
+* [forums](https://forums.t1n1wall.com/)
 
 ### ZRouter
 ZRouter.org is a FreeBSD based firmware for embedded devices.
 
-* [official site](http://zrouter.org/)
-* [files](http://zrouter.org/projects/zrouter/files)
+* [official site](https://zrouter.org/)
+* [files](https://zrouter.org/projects/zrouter/files)
 
 ## BSD news
 
@@ -193,62 +206,49 @@ In this section you can find sites presenting news about BSD.
 * [BSDSec.net](https://bsdsec.net/) – deadsimple BSD Security Advisories and Announcements 
 * [BSD Weekly](https://bsdweekly.com/) – a free, once–weekly e-mail round-up of BSD news and articles.
 * [DiscoverBSD.com](https://www.discoverbsd.com/) – discovering the Way of the BSD
-* [DragonFly BSD Digest](https://www.dragonflydigest.com/) – a running description of activity related to DragonFly BSD.
-* [FreeBSDNews](https://www.freebsdnews.com/) – a blog advocating FreeBSD and offering project news and advice.
-* [NetBSD Planet](http://netbsd.fi/)
-* [OpenBSD Journal](http://undeadly.org/) – a resource for the OpenBSD community
-* [Phoronix](http://www.phoronix.com/scan.php?page=news_topic&q=BSD) 
+* [Phoronix](https://www.phoronix.com/scan.php?page=news_topic&q=BSD) 
 * [Planet FreeBSD](https://planet.xbsd.net/)
-* [Slashdot](http://bsd.slashdot.org/) – BSD section of the popular Slashdot open source news and forum site.
+* [Slashdot](https://bsd.slashdot.org/) – BSD section of the popular Slashdot open source news and forum site.
 
 ### Podcasts 
 
-* [BSDNow](http://www.bsdnow.tv/) – weekly BSD podcast, featuring news, interviews and tutorials, in MP3, OGG and MP4
-* [BSDTalk](http://bsdtalk.blogspot.com/) – talking about the BSD family of free operating systems.
-* [Garbage (archive)](https://garbage.jcs.org/) – a podcast about technology, much of it garbage. (Archived episodes)
+* [BSDNow](https://www.bsdnow.tv/) – weekly BSD podcast, featuring news, interviews and tutorials, in MP3, OGG and MP4
+* [BSDTalk](https://bsdtalk.blogspot.com/) – talking about the BSD family of free operating systems
+* [Garbage (archive)](https://garbage.jcs.org/) – a podcast about technology, much of it garbage (archived episodes).
 
-## Forums and Communities
+## Forums and communities
 
 ### Forums
 
-* [BSDForen](http://www.bsdforen.de/)
+* [BSD – UNIX and Linux Forums](https://www.unix.com/bsd/)
+* [BSDForen](https://www.bsdforen.de/)
 * [Daemon Forums](http://daemonforums.org/)
-* [Unix.com](http://www.unix.com/bsd/)
-* [UnitedBSD](https://www.unitedbsd.com)
+* [UnitedBSD](https://www.unitedbsd.com/)
+
+### Meetup
+
+* [BSD Meetup](https://bsd.meetup.com/) – sign up required
 
 ### Reddit
 
 * [/r/bsd](https://www.reddit.com/r/bsd)
 * [/r/bsdsec](https://www.reddit.com/r/bsdsec)
-* [/r/dragonflybsd](https://www.reddit.com/r/dragonflybsd)
-* [/r/freebsd](https://www.reddit.com/r/freebsd)
-* [/r/hardenedbsd](https://www.reddit.com/r/hardenedbsd)
-* [/r/netbsd](https://www.reddit.com/r/netbsd)
-* [/r/openbsd](https://www.reddit.com/r/openbsd)
-* [/r/openbsd_gaming/](https://www.reddit.com/r/openbsd_gaming)
-* [/r/opnsense](https://www.reddit.com/r/opnsense) – private 
-* [/r/OPNsenseFirewall](https://www.reddit.com/r/OPNsenseFirewall)
 * [/r/unixporn](https://www.reddit.com/r/unixporn)
 
-### Meetups
-
-* [BSD Meetup](http://bsd.meetup.com/)
-
-### User Groups
+### User groups
 
 * [AMBUG](https://ambug.org/) – Armenia BSD User Group
 * [BSD-PL](https://bsd-pl.org/en) – Polish BSD User Group
-* [HELBUG](http://helbug.fi) – Helsinki area BSD User Group
+* [HELBUG](http://helbug.fi/) – Helsinki area BSD User Group
 * [FreeBSD Groups](https://www.freebsd.org/usergroups.html)
 * [Knoxville BSD User Group](http://knoxbug.org/)
-* [MetaBUG](http://www.metabug.org/) – a global BSD users group federation
+* [MetaBUG](https://www.metabug.org/) – a global BSD users group federation
 * [NetBSD Groups](https://www.netbsd.org/community/groups.html)
 * [New York City \*BSD User Group](https://nycbug.org/)
-* [New Delhi BSD User Group](http://ndbug.in)
-* [OpenBSD Groups](http://www.openbsd.org/groups.html)
+* [New Delhi BSD User Group](https://ndbug.in/)
+* [OpenBSD user groups](https://www.openbsd.org/groups.html)
 * [Orlando BSD user group](https://www.orlandobsd.org/)
 * [Southeast Michigan BSD User Group](http://www.semibug.org/)
-
 
 ### Community initiatives
 
@@ -280,7 +280,7 @@ In this section you can find sites presenting news about BSD.
 
 ## Gaming
 * [linuxulator-steam-utils](https://github.com/shkhln/linuxulator-steam-utils) – a set of workarounds for running the Linux Steam client under the FreeBSD Linux emulation layer
-* [The Homura Project](https://codeberg.org/Alexander88207/Homura) – Windows games launcher for FreeBSD
+* [Suyimazu](https://codeberg.org/Alexander88207/Suyimazu) – Wine-based game launcher for FreeBSD
 
 ## Other
 * [The Unix Tree](https://www.tuhs.org/cgi-bin/utree.pl) – browse the source code and manuals of various old versions of Unix (including BSDs)

--- a/README.md
+++ b/README.md
@@ -232,10 +232,10 @@ In this section you can find sites presenting news about BSD.
 
 ### Forums
 
-* [UNIX/BSD – Unix Linux Community](https://community.unix.com/c/unix/bsd/34)
 * [BSDForen](https://www.bsdforen.de/)
 * [Daemon Forums](http://daemonforums.org/)
 * [UnitedBSD](https://www.unitedbsd.com/)
+* [UNIX/BSD – Unix Linux Community](https://community.unix.com/c/unix/bsd/34)
 
 ### Meetup
 

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ In this section you can find sites presenting news about BSD.
 
 ### Forums
 
-* [BSD – UNIX and Linux Forums](https://community.unix.com/c/unix/bsd/34)
+* [UNIX/BSD – Unix Linux Community](https://community.unix.com/c/unix/bsd/34)
 * [BSDForen](https://www.bsdforen.de/)
 * [Daemon Forums](http://daemonforums.org/)
 * [UnitedBSD](https://www.unitedbsd.com/)

--- a/README.md
+++ b/README.md
@@ -4,16 +4,16 @@ This document is a database of links related to the BSD operating systems and BS
 
 [Structure](https://github.com/DiscoverBSD/BSD-Links/issues/1) is as follows:
  
-* [Operating Systems](#operating-systems) - official links
-* [BSD News](#bsd-news) - where to look for news?
-* [Forums and communities](#forums-and-communities) - reddit, forums, meetups etc
-* [Learning](#learning) - where to learn BSD
-* [Books](#books) - books about BSD
-* [BSD related software](#bsd-related-software)
+* [Operating systems](#operating-systems) – official links
+* [BSD news](#bsd-news) – where to look for news
+* [Forums and communities](#forums-and-communities) – Reddit, forums, meetups etc
+* [Learning](#learning) – where to learn BSD
+* [Books](#books) – books about BSD
+* [BSD-related software](#bsd-related-software)
 * [Gaming](#gaming)
 * [Other](#other)
 
-## Operating Systems
+## Operating systems
 In this section you can find official BSD OSes links (in alphabethical order ) with short description as can be found on their pages. 
 
 ### Bitrig
@@ -46,7 +46,7 @@ EdgeBSD is a new member of the family of [BSD](http://en.wikipedia.org/wiki/BSD)
 * [Twitter](https://twitter.com/EdgeBSD)
 
 ### FreeBSD
-Founded in 1993, FreeBSD is an advanced operating system that powers modern [desktops, servers and embedded devices](https://www.freebsd.org/platforms/). Advanced features make FreeBSD the [platform of choice](https://freebsdfoundation.org/freebsd-project/what-is-freebsd/) for many of the most pervasive embedded networking and storage devices, and busiest websites. [FreeBSD developers](https://docs.freebsd.org/en/articles/contributors/#staff-committers) form part of a [diverse and extensive community](https://www.freebsd.org/community/); members are welcoming and approachable. There's focus on widespread use, and on building the best possible system. Experienced users and developers are [always willing to help the less experienced](https://www.freebsd.org/advocacy/whyusefreebsd/).
+Founded in 1993, FreeBSD is an advanced operating system that powers modern [desktops, servers and embedded devices](https://www.freebsd.org/platforms/). Advanced features make FreeBSD the [system of choice](https://freebsdfoundation.org/freebsd-project/what-is-freebsd/) for many of the most pervasive embedded networking and storage devices, and busiest websites. [FreeBSD developers](https://docs.freebsd.org/en/articles/contributors/#staff-committers) form part of a [diverse and extensive community](https://www.freebsd.org/community/); members are welcoming and approachable. There's focus on widespread use, and on building the best possible system. Experienced users and developers are [always willing to help the less experienced](https://www.freebsd.org/advocacy/whyusefreebsd/).
 
 * [official site](https://www.freebsd.org)
 * [download](https://www.freebsd.org/where.html)
@@ -128,7 +128,7 @@ The OpenBSD project produces a FREE, multi-platform 4.4BSD-based UNIX-like opera
 * [download](http://www.openbsd.org/ftp.html)
 * [mailing list](http://www.openbsd.org/mail.html)
 * [Twitter](https://twitter.com/openbsd)
-* [openbsd-awesome](https://github.com/ligurio/openbsd-awesome) - the curated list of awesome OpenBSD products, vacancies, resources.
+* [openbsd-awesome](https://github.com/ligurio/openbsd-awesome) – the curated list of awesome OpenBSD products, vacancies and resources
 * [OpenBSD Jumpstart](http://www.openbsdjumpstart.org/)
 
 ### OPNsense
@@ -183,29 +183,29 @@ ZRouter.org is a FreeBSD based firmware for embedded devices.
 * [official site](http://zrouter.org/)
 * [files](http://zrouter.org/projects/zrouter/files)
 
-## BSD News
+## BSD news
 
 In this section you can find sites presenting news about BSD. 
 
 ### News sites
 
-* [#BSDHistory](https://bsdhistory.discoverbsd.com/) - tweet-sized facts about BSDs
-* [BSDSec.net](https://bsdsec.net/) - deadsimple BSD Security Advisories and Announcements 
-* [BSD Weekly](https://bsdweekly.com/) - a free, once–weekly e-mail round-up of BSD news and articles.
-* [DiscoverBSD.com](https://www.discoverbsd.com/) - Discovering the Way of the BSD
-* [DragonFly BSD Digest](https://www.dragonflydigest.com/) - A running description of activity related to DragonFly BSD.
-* [FreeBSDNews](https://www.freebsdnews.com/) - A blog advocating FreeBSD and offering project news and advice.
+* [#BSDHistory](https://bsdhistory.discoverbsd.com/) – tweet-sized facts about BSDs
+* [BSDSec.net](https://bsdsec.net/) – deadsimple BSD Security Advisories and Announcements 
+* [BSD Weekly](https://bsdweekly.com/) – a free, once–weekly e-mail round-up of BSD news and articles.
+* [DiscoverBSD.com](https://www.discoverbsd.com/) – discovering the Way of the BSD
+* [DragonFly BSD Digest](https://www.dragonflydigest.com/) – a running description of activity related to DragonFly BSD.
+* [FreeBSDNews](https://www.freebsdnews.com/) – a blog advocating FreeBSD and offering project news and advice.
 * [NetBSD Planet](http://netbsd.fi/)
-* [OpenBSD Journal](http://undeadly.org/) - A resource for the OpenBSD community
+* [OpenBSD Journal](http://undeadly.org/) – a resource for the OpenBSD community
 * [Phoronix](http://www.phoronix.com/scan.php?page=news_topic&q=BSD) 
 * [Planet FreeBSD](https://planet.xbsd.net/)
-* [Slashdot](http://bsd.slashdot.org/) - BSD section of the popular Slashdot open source news and forum site.
+* [Slashdot](http://bsd.slashdot.org/) – BSD section of the popular Slashdot open source news and forum site.
 
 ### Podcasts 
 
-* [BSDNow](http://www.bsdnow.tv/) -  weekly BSD podcast, featuring news, interviews and tutorials, in MP3, OGG and MP4
-* [BSDTalk](http://bsdtalk.blogspot.com/) - Talking about the BSD family of free operating systems.
-* [Garbage (archive)](https://garbage.jcs.org/) - A podcast about technology, much of it garbage. (Archived episodes)
+* [BSDNow](http://www.bsdnow.tv/) – weekly BSD podcast, featuring news, interviews and tutorials, in MP3, OGG and MP4
+* [BSDTalk](http://bsdtalk.blogspot.com/) – talking about the BSD family of free operating systems.
+* [Garbage (archive)](https://garbage.jcs.org/) – a podcast about technology, much of it garbage. (Archived episodes)
 
 ## Forums and Communities
 
@@ -225,9 +225,9 @@ In this section you can find sites presenting news about BSD.
 * [/r/hardenedbsd](https://www.reddit.com/r/hardenedbsd)
 * [/r/netbsd](https://www.reddit.com/r/netbsd)
 * [/r/openbsd](https://www.reddit.com/r/openbsd)
-* [/r/openbsd_gaming/](https://www.reddit.com/r/openbsd_gaming/)
-* [/r/opnsense](https://www.reddit.com/r/opnsense) - private 
-* [/r/OPNsenseFirewall](https://www.reddit.com/r/OPNsenseFirewall/)
+* [/r/openbsd_gaming/](https://www.reddit.com/r/openbsd_gaming)
+* [/r/opnsense](https://www.reddit.com/r/opnsense) – private 
+* [/r/OPNsenseFirewall](https://www.reddit.com/r/OPNsenseFirewall)
 * [/r/unixporn](https://www.reddit.com/r/unixporn)
 
 ### Meetups
@@ -236,12 +236,12 @@ In this section you can find sites presenting news about BSD.
 
 ### User Groups
 
-* [AMBUG](https://ambug.org/) - Armenia BSD User Group
-* [BSD-PL](https://bsd-pl.org/en) - Polish BSD User Group
-* [HELBUG](http://helbug.fi) - Helsinki area BSD User Group
+* [AMBUG](https://ambug.org/) – Armenia BSD User Group
+* [BSD-PL](https://bsd-pl.org/en) – Polish BSD User Group
+* [HELBUG](http://helbug.fi) – Helsinki area BSD User Group
 * [FreeBSD Groups](https://www.freebsd.org/usergroups.html)
 * [Knoxville BSD User Group](http://knoxbug.org/)
-* [MetaBUG](http://www.metabug.org/) - A Global BSD Users Group Federation
+* [MetaBUG](http://www.metabug.org/) – a global BSD users group federation
 * [NetBSD Groups](https://www.netbsd.org/community/groups.html)
 * [New York City \*BSD User Group](https://nycbug.org/)
 * [New Delhi BSD User Group](http://ndbug.in)
@@ -252,13 +252,13 @@ In this section you can find sites presenting news about BSD.
 
 ### Community initiatives
 
-* [BSD Hardware](https://bsd-hardware.info/) - A project to collect hardware details of BSD-powered computers and help users and developers to debug hardware related issues, check for compatibility and find drivers
-* [dmesgd](https://dmesgd.nycbug.org/) - A user-submitted repository of searchable \*BSD dmesgs, maintained by NYC\*BUG
+* [BSD Hardware](https://bsd-hardware.info/) – a project to collect hardware details of BSD-powered computers and help users and developers to debug hardware related issues, check for compatibility and find drivers
+* [dmesgd](https://dmesgd.nycbug.org/) – a user-submitted repository of searchable \*BSD dmesgs, maintained by NYC\*BUG
 
 ## Learning
 
-* [The BSD Certification Group](http://www.bsdcertification.org/) - The BSD Certification Group Inc. is a non-profit organization committed to creating and maintaining a global certification standard for system administration on BSD based operating systems.
-* [TeachBSD](http://teachbsd.org/) - Teaching Operating Systems with Tracing : a set of courses for students and software practitioners. 
+* [The BSD Certification Group](http://www.bsdcertification.org/) – a non-profit organization committed to creating and maintaining a global certification standard for system administration on BSD based operating systems.
+* [TeachBSD](http://teachbsd.org/) – Teaching Operating Systems with Tracing : a set of courses for students and software practitioners. 
 
 ## Books
 * [Absolute FreeBSD 3rd Ed](https://mwl.io/nonfiction/os#af3e)
@@ -273,14 +273,14 @@ In this section you can find sites presenting news about BSD.
 
 ## BSD related software
 
-* [Bastille](https://bastillebsd.org/) - Bastille helps you quickly create and manage FreeBSD Jails
-* [CBSD](https://www.bsdstore.ru/en/about.html) - CBSD is a management layer written for the FreeBSD jail(8) subsystem, bhyve and Xen
-* [Runhyve](https://runhyve.app/) - The Virtual Machines Manager for Bhyve
-* [BSD-Cloud-Image](https://bsd-cloud-image.org/) - A collection of (unofficial) prebuilt BSD cloud images, for instance for OpenStack
+* [Bastille](https://bastillebsd.org/) – Bastille helps you quickly create and manage FreeBSD Jails
+* [CBSD](https://www.bsdstore.ru/en/about.html) – CBSD is a management layer written for the FreeBSD jail(8) subsystem, bhyve and Xen
+* [Runhyve](https://runhyve.app/) – the virtual machines manager for Bhyve
+* [BSD-Cloud-Image](https://bsd-cloud-image.org/) – a collection of (unofficial) prebuilt BSD cloud images, for instance for OpenStack
 
 ## Gaming
-* [linuxulator-steam-utils](https://github.com/shkhln/linuxulator-steam-utils) - A set of workarounds for running the Linux Steam client under the FreeBSD Linux emulation layer
-* [The Homura Project](https://codeberg.org/Alexander88207/Homura) - Windows Games Launcher for FreeBSD
+* [linuxulator-steam-utils](https://github.com/shkhln/linuxulator-steam-utils) – a set of workarounds for running the Linux Steam client under the FreeBSD Linux emulation layer
+* [The Homura Project](https://codeberg.org/Alexander88207/Homura) – Windows games launcher for FreeBSD
 
 ## Other
-* [The Unix Tree](https://www.tuhs.org/cgi-bin/utree.pl) - Browse the source code and manuals of various old versions of Unix (including BSDs)
+* [The Unix Tree](https://www.tuhs.org/cgi-bin/utree.pl) – browse the source code and manuals of various old versions of Unix (including BSDs)

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ In this section you can find sites presenting news about BSD.
 
 ### Forums
 
-* [BSD – UNIX and Linux Forums](https://www.unix.com/bsd/)
+* [BSD – UNIX and Linux Forums](https://community.unix.com/c/unix/bsd/34)
 * [BSDForen](https://www.bsdforen.de/)
 * [Daemon Forums](http://daemonforums.org/)
 * [UnitedBSD](https://www.unitedbsd.com/)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Bitrig is a free, fast, and secure Unix-like Open Source operating system. It is
 
 * [official site](https://www.bitrig.org/)
 * [downloads](https://www.bitrig.org/downloads.html)
-* [twitter](https://twitter.com/bitrig)
+* [Twitter](https://twitter.com/bitrig)
 
 ### BSD Router Project
 BSD Router Project (BSDRP) is an embedded free and open source router distribution based on [FreeBSD](http://www.freebsd.org/) with [Quagga](http://www.quagga.net/) and [Bird](http://bird.network.cz/).
@@ -43,17 +43,17 @@ EdgeBSD is a new member of the family of [BSD](http://en.wikipedia.org/wiki/BSD)
 
 * [official site](https://www.edgebsd.org/)
 * [projects](https://www.edgebsd.org/edgebsd/project)
-* [twitter](https://twitter.com/EdgeBSD)
+* [Twitter](https://twitter.com/EdgeBSD)
 
 ### FreeBSD
-FreeBSD is an advanced computer operating system used to power modern servers, desktops and embedded [platforms](https://www.freebsd.org/platforms/). A large [community](https://www.freebsd.org/doc/en_US.ISO8859-1/articles/contributors/staff-committers.html) has continually developed it for more than thirty years. Its advanced networking, security and storage features have made FreeBSD the platform of choice for many of the [busiest web](https://www.freebsd.org/doc/en_US.ISO8859-1/books/handbook/nutshell.html#introduction-nutshell-users) sites and most pervasive embedded networking and storage devices.
+Founded in 1993, FreeBSD is an advanced operating system that powers modern [desktops, servers and embedded devices](https://www.freebsd.org/platforms/). Advanced features make FreeBSD the [platform of choice](https://freebsdfoundation.org/freebsd-project/what-is-freebsd/) for many of the most pervasive embedded networking and storage devices, and busiest websites. [FreeBSD developers](https://docs.freebsd.org/en/articles/contributors/#staff-committers) form part of a [diverse and extensive community](https://www.freebsd.org/community/); members are welcoming and approachable. There's focus on widespread use, and on building the best possible system. Experienced users and developers are [always willing to help the less experienced](https://www.freebsd.org/advocacy/whyusefreebsd/).
 
-* [official site](https://freebsd.org)
+* [official site](https://www.freebsd.org)
 * [download](https://www.freebsd.org/where.html)
 * [forum](https://forums.freebsd.org/)
-* [twitter](https://twitter.com/freebsd)
-* [handbook](https://www.freebsd.org/doc/en_US.ISO8859-1/books/handbook/)
-* [mailing list](https://www.freebsd.org/community/mailinglists.html)
+* [Twitter](https://twitter.com/freebsd)
+* [handbook](https://docs.freebsd.org/en/books/handbook/)
+* [mailing list](https://www.freebsd.org/community/mailinglists/)
 
 ### GhostBSD
 GhostBSD is a user-friendly BSD operating system built on top of [FreeBSD](#freebsd). GhostBSD aims to provide a familiar workstation with all of the features and benefits of FreeBSD, combined with a twist that is the MATE desktop environment and a focus on user-friendliness. Available in both 32- and 64-bit versions, GhostBSD is suitable for newcomers, as well as experienced BSD users.
@@ -90,7 +90,7 @@ MidnightBSD is a new BSD-derived operating system developed with desktop users i
 * [official site](http://www.midnightbsd.org/)
 * [download](http://www.midnightbsd.org/download/)
 * [mailing list](http://www.midnightbsd.org/mailman/listinfo/)
-* [twitter](https://twitter.com/midnightbsd)
+* [Twitter](https://twitter.com/midnightbsd)
 
 ### MirOS
 MirOS BSD is a secure operating system from the BSD family for 32-bit i386 and sparc systems. It is based on 4.4BSD-Lite (mostly OpenBSD, some NetBSD®). The MirPorts Framework is a portable ports tree to facilitate the installation of additional software. The project also releases some portable software: mksh, a pdksh-based shell; PaxMirabilis, an archiver for various formats; MirMake, a framework for building software; MirNroff, an AT&T nroff based man page (and text document) formatter; MirCksum, a flexible checksumming and hash generation tool; and some more.
@@ -127,7 +127,7 @@ The OpenBSD project produces a FREE, multi-platform 4.4BSD-based UNIX-like opera
 * [official site](http://www.openbsd.org)
 * [download](http://www.openbsd.org/ftp.html)
 * [mailing list](http://www.openbsd.org/mail.html)
-* [twitter](https://twitter.com/openbsd)
+* [Twitter](https://twitter.com/openbsd)
 * [openbsd-awesome](https://github.com/ligurio/openbsd-awesome) - the curated list of awesome OpenBSD products, vacancies, resources.
 * [OpenBSD Jumpstart](http://www.openbsdjumpstart.org/)
 
@@ -137,7 +137,7 @@ OPNsense is an open source,easy-to-use and easy-to-build FreeBSD based firewall 
 * [official site](https://opnsense.org)
 * [download](https://opnsense.org/download/)
 * [mailing list](https://opnsense.org/support-overview/mailing-list/)
-* [twitter](https://twitter.com/opnsense)
+* [Twitter](https://twitter.com/opnsense)
 
 ### OS108
 OS108 is a fast, open and Secure replacement Operating System for Windows and macOS. Built on top of NetBSD, OS108 provides a simple desktop-oriented operating system.
@@ -189,7 +189,7 @@ In this section you can find sites presenting news about BSD.
 
 ### News sites
 
-* [#BSDHistory](https://bsdhistory.discoverbsd.com/) - twitter-sized facts about BSDs
+* [#BSDHistory](https://bsdhistory.discoverbsd.com/) - tweet-sized facts about BSDs
 * [BSDSec.net](https://bsdsec.net/) - deadsimple BSD Security Advisories and Announcements 
 * [BSD Weekly](https://bsdweekly.com/) - a free, once–weekly e-mail round-up of BSD news and articles.
 * [DiscoverBSD.com](https://www.discoverbsd.com/) - Discovering the Way of the BSD
@@ -229,7 +229,6 @@ In this section you can find sites presenting news about BSD.
 * [/r/opnsense](https://www.reddit.com/r/opnsense) - private 
 * [/r/OPNsenseFirewall](https://www.reddit.com/r/OPNsenseFirewall/)
 * [/r/unixporn](https://www.reddit.com/r/unixporn)
-
 
 ### Meetups
 
@@ -285,4 +284,3 @@ In this section you can find sites presenting news about BSD.
 
 ## Other
 * [The Unix Tree](https://www.tuhs.org/cgi-bin/utree.pl) - Browse the source code and manuals of various old versions of Unix (including BSDs)
-

--- a/README.md
+++ b/README.md
@@ -225,6 +225,11 @@ In this section you can find sites presenting news about BSD.
 
 ## Forums and communities
 
+### Community initiatives
+
+* [BSD Hardware](https://bsd-hardware.info/) – a project to collect hardware details of BSD-powered computers and help users and developers to debug hardware related issues, check for compatibility and find drivers
+* [dmesgd](https://dmesgd.nycbug.org/) – a user-submitted repository of searchable \*BSD dmesgs, maintained by NYC\*BUG
+
 ### Forums
 
 * [BSD – UNIX and Linux Forums](https://www.unix.com/bsd/)
@@ -256,11 +261,6 @@ In this section you can find sites presenting news about BSD.
 * [OpenBSD user groups](https://www.openbsd.org/groups.html)
 * [Orlando BSD user group](https://www.orlandobsd.org/)
 * [Southeast Michigan BSD User Group](http://www.semibug.org/)
-
-### Community initiatives
-
-* [BSD Hardware](https://bsd-hardware.info/) – a project to collect hardware details of BSD-powered computers and help users and developers to debug hardware related issues, check for compatibility and find drivers
-* [dmesgd](https://dmesgd.nycbug.org/) – a user-submitted repository of searchable \*BSD dmesgs, maintained by NYC\*BUG
 
 ## Learning
 


### PR DESCRIPTION
Alphabetical order for subsections within the _Forums and communities_ section. 

<https://www.unix.com/bsd/> redirects to <https://community.unix.com/> when logging in, then <https://community.unix.com/c/unix/bsd/34> is the BSD subcatetory of the UNIX category at _Unix Linux Community_. 